### PR TITLE
チャンネル情報（チャンネル名、チャンネルトピック）をrandomチャンネルに出力した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
+gem 'discordrb'
 gem 'dotenv'
 gem 'rubocop', require: false
-gem 'discordrb'

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 
 gem 'dotenv'
 gem 'rubocop', require: false
+gem 'discordrb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,38 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    discordrb (3.4.0)
+      discordrb-webhooks (~> 3.3.0)
+      ffi (>= 1.9.24)
+      opus-ruby
+      rest-client (>= 2.0.0)
+      websocket-client-simple (>= 0.3.0)
+    discordrb-webhooks (3.3.0)
+      rest-client (>= 2.1.0.rc1)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
+    event_emitter (0.2.6)
+    ffi (1.15.5)
+    http-accept (1.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    netrc (0.11.0)
+    opus-ruby (1.0.1)
+      ffi
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     regexp_parser (2.2.1)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rubocop (1.25.1)
       parallel (~> 1.10)
@@ -21,12 +47,20 @@ GEM
     rubocop-ast (1.16.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    websocket (1.2.9)
+    websocket-client-simple (0.5.1)
+      event_emitter
+      websocket
 
 PLATFORMS
   x86_64-darwin-21
 
 DEPENDENCIES
+  discordrb
   dotenv
   rubocop
 

--- a/announce.rb
+++ b/announce.rb
@@ -4,4 +4,7 @@ require 'dotenv/load'
 bot = Discordrb::Bot.new(token: ENV['DISCORD_BOT_TOKEN'],
                          client_id: ENV['DISCORD_CLIENT_ID'])
 
+channels = Discordrb::API::Server.channels(ENV['DISCORD_BOT_TOKEN'],
+                                           ENV['DISCORD_SERVER_ID'])
+p JSON.parse(channels)
 bot.run

--- a/announce.rb
+++ b/announce.rb
@@ -1,0 +1,7 @@
+require 'discordrb'
+require 'dotenv/load'
+
+bot = Discordrb::Bot.new(token: ENV['DISCORD_BOT_TOKEN'],
+                         client_id: ENV['DISCORD_CLIENT_ID'])
+
+bot.run

--- a/announce.rb
+++ b/announce.rb
@@ -10,6 +10,13 @@ channels = JSON.parse(channels)
 text_channels = channels.select { |c| (c['type']).zero? }
 ramdom_index = rand(0...text_channels.count)
 text_channel = text_channels[ramdom_index]
-p text_channel_name = text_channel['name']
-p text_channel_topic = text_channel['topic']
+text_channel_name = text_channel['name']
+text_channel_topic = text_channel['topic']
+message = "本日のチャンネル紹介\nチャンネル名： ##{text_channel_name}\n説明： #{text_channel_topic}"
+
+Discordrb::API::Channel.create_message(ENV['DISCORD_BOT_TOKEN'],
+                                       ENV['DISCORD_RANDOM_CHANNEL_ID'],
+                                       message)
+
+
 bot.run

--- a/announce.rb
+++ b/announce.rb
@@ -6,5 +6,7 @@ bot = Discordrb::Bot.new(token: ENV['DISCORD_BOT_TOKEN'],
 
 channels = Discordrb::API::Server.channels(ENV['DISCORD_BOT_TOKEN'],
                                            ENV['DISCORD_SERVER_ID'])
-p JSON.parse(channels)
+channels = JSON.parse(channels)
+p text_channels = channels.select { |c| (c['type']).zero? }
+
 bot.run

--- a/announce.rb
+++ b/announce.rb
@@ -12,7 +12,10 @@ ramdom_index = rand(0...text_channels.count)
 text_channel = text_channels[ramdom_index]
 text_channel_name = text_channel['name']
 text_channel_topic = text_channel['topic']
-message = "本日のチャンネル紹介\nチャンネル名： ##{text_channel_name}\n説明： #{text_channel_topic}"
+message = "本日のチャンネル紹介\nチャンネル名： ##{text_channel_name}"
+topic_message = "\n説明： #{text_channel_topic}"
+message += topic_message unless text_channel_topic.nil?
+
 
 Discordrb::API::Channel.create_message(ENV['DISCORD_BOT_TOKEN'],
                                        ENV['DISCORD_RANDOM_CHANNEL_ID'],

--- a/announce.rb
+++ b/announce.rb
@@ -10,5 +10,6 @@ channels = JSON.parse(channels)
 text_channels = channels.select { |c| (c['type']).zero? }
 ramdom_index = rand(0...text_channels.count)
 text_channel = text_channels[ramdom_index]
-p text_channel
+p text_channel_name = text_channel['name']
+p text_channel_topic = text_channel['topic']
 bot.run

--- a/announce.rb
+++ b/announce.rb
@@ -7,6 +7,8 @@ bot = Discordrb::Bot.new(token: ENV['DISCORD_BOT_TOKEN'],
 channels = Discordrb::API::Server.channels(ENV['DISCORD_BOT_TOKEN'],
                                            ENV['DISCORD_SERVER_ID'])
 channels = JSON.parse(channels)
-p text_channels = channels.select { |c| (c['type']).zero? }
-
+text_channels = channels.select { |c| (c['type']).zero? }
+ramdom_index = rand(0...text_channels.count)
+text_channel = text_channels[ramdom_index]
+p text_channel
 bot.run

--- a/announce.rb
+++ b/announce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'discordrb'
 require 'dotenv/load'
 
@@ -16,10 +18,8 @@ message = "本日のチャンネル紹介\nチャンネル名： ##{text_channel
 topic_message = "\n説明： #{text_channel_topic}"
 message += topic_message unless text_channel_topic.nil?
 
-
 Discordrb::API::Channel.create_message(ENV['DISCORD_BOT_TOKEN'],
                                        ENV['DISCORD_RANDOM_CHANNEL_ID'],
                                        message)
-
 
 bot.run


### PR DESCRIPTION
- #3 

## やったこと
**テキストチャンネルの情報（チャンネル名、チャンネルトピック）をrandomチャンネルに出力**

botがチャンネル名とチャンネルトピックをアナウンスしてくれる。（チャンネルトピックがない時は、チャンネル名だけ表示される。）

![image](https://user-images.githubusercontent.com/66904873/157234267-821ec91a-5b3b-41fa-ad56-61d43001d264.png)

![image](https://user-images.githubusercontent.com/66904873/157234563-5dd9ff78-c4b3-44ef-a3da-cbd946650b79.png)

## 関連
- #6 