### PR TITLE
Herokuスケジューラーが実行されるよう修正

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-bot: bundle exec ruby bin/bot_run.rb

--- a/bin/bot_run.rb
+++ b/bin/bot_run.rb
@@ -3,4 +3,3 @@
 require_relative '../lib/bot_message'
 
 BotMessage.create
-BotMessage.run

--- a/lib/discord_api.rb
+++ b/lib/discord_api.rb
@@ -4,9 +4,6 @@ require 'discordrb'
 require 'dotenv/load'
 
 module DiscordApi
-  BOT = Discordrb::Bot.new(token: ENV['DISCORD_BOT_TOKEN'],
-                           client_id: ENV['DISCORD_CLIENT_ID'])
-
   ALL_CHANNELS = Discordrb::API::Server.channels(ENV['DISCORD_BOT_TOKEN'],
                                                  ENV['DISCORD_SERVER_ID'])
 


### PR DESCRIPTION
## 該当するIssue
- #5 
- #42  
- #43 

## 概要
Botが定期実行されない（Herokuスケジューラーが実行されない）という問題をこのPRで修正

## 原因
必要がないのにも関わらず、`Discordrb::Bot.new`をしてしまっていて、それをずっとHerokuスケジューラーを使って動かしてしまっていた。
本来自分が動かしたかったのは、`BotMessage.create`（`DiscordApi.create_message(...)`）の方だけ。それにプラスして`BotMessage.run`（`Discordrb::Bot.new`(...)）を動かしてしまっていた。
スケジューラーを起動して、その次のスケジューラーを起動させるときに前のプロセスが終了していないといけないのに、プロセスが残ったままになっていて、その結果、Herokuスケジューラーが混乱してしまったというのがざっくりとした原因。

混乱したという点を具体的に。
（1時間ごとにスケジューラーが起動するよう設定している場合）
まず初めにコマンドが実行される。（きちんとスケジューラーが起動されている。）→1時間後、次のスケジュールにより再びコマンド実行しようとするも、前のプロセスがまだ残っているためそのプロセスを殺すという実行をする。これでこのスケジュールの仕事が終わりになっている。→1時間後、次のスケジュールは実行されない。
というのが1サイクルで実行されていた。

次の実行をしたい時に前のプロセスが残っている場合、前のプロセスを殺す。というのが下記に書かれている。
https://devcenter.heroku.com/articles/scheduler#long-running-jobs
> A dyno started by scheduler will not run longer than its scheduling interval. For example, for a job that runs every 10 minutes, dynos will be terminated after running for approximately 10 minutes.
Note that there is some jitter in the dyno termination scheduling. This means that two dynos running the same job may overlap for a brief time when a new one is started.

## わかってないこと
- 前のプロセスが残っている場合、そのプロセスを殺してスケジューラーは実行せずに終了されるのが何故なのかよくわかっていない...

- 「起動される→終了する→1時間間が空く」という1サイクルで、なぜ最後に1時間間が空くのかわかっていない...