### PR TITLE
lib/bot_message.rbのテストを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,5 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 3.1.1
   NewCops: enable
+
+require: rubocop-minitest

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 group :development do
   gem 'rubocop', require: false
   gem 'rubocop-fjord', require: false
+  gem 'rubocop-minitest', require: false
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,10 @@ group :development do
   gem 'rubocop-fjord', require: false
 end
 
+group :test do
+  gem 'minitest'
+  gem 'webmock'
+end
+
 gem 'discordrb'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,8 @@ GEM
     rubocop-fjord (0.2.0)
       rubocop (>= 1.0)
       rubocop-performance
+    rubocop-minitest (0.18.0)
+      rubocop (>= 0.90, < 2.0)
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -85,6 +87,7 @@ DEPENDENCIES
   minitest
   rubocop
   rubocop-fjord
+  rubocop-minitest
   webmock
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     byebug (11.1.3)
+    crack (0.4.5)
+      rexml
     discordrb (3.4.0)
       discordrb-webhooks (~> 3.3.0)
       ffi (>= 1.9.24)
@@ -16,18 +20,21 @@ GEM
     dotenv (2.7.6)
     event_emitter (0.2.6)
     ffi (1.15.5)
+    hashdiff (1.0.1)
     http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    minitest (5.15.0)
     netrc (0.11.0)
     opus-ruby (1.0.1)
       ffi
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
+    public_suffix (4.0.6)
     rainbow (3.1.1)
     regexp_parser (2.2.1)
     rest-client (2.1.0)
@@ -58,6 +65,10 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-client-simple (0.5.1)
       event_emitter
@@ -71,8 +82,10 @@ DEPENDENCIES
   byebug
   discordrb
   dotenv
+  minitest
   rubocop
   rubocop-fjord
+  webmock
 
 RUBY VERSION
    ruby 3.1.1p18

--- a/lib/bot_message.rb
+++ b/lib/bot_message.rb
@@ -4,16 +4,12 @@ require_relative 'bot_message_formatter'
 
 class BotMessage
   class << self
-    def create
-      DiscordApi.create_message(BotMessage.message, BotMessage.embed_message)
+    def create(description = nil)
+      DiscordApi.create_message(BotMessage.message, BotMessageFormatter.new.create_embed_message(embed_description: description))
     end
 
     def message
       BotMessageFormatter::MESSAGE
-    end
-
-    def embed_message
-      BotMessageFormatter.new.create_embed_message
     end
   end
 end

--- a/lib/bot_message_formatter.rb
+++ b/lib/bot_message_formatter.rb
@@ -11,7 +11,7 @@ class BotMessageFormatter
     @text_channel = select_hobby_category_channels.sample
   end
 
-  def create_embed_message(embed_description: nil )
+  def create_embed_message(embed_description: nil)
     {
       title: EMBED_TITLE,
       description: embed_description || format_embed_description,

--- a/lib/bot_message_formatter.rb
+++ b/lib/bot_message_formatter.rb
@@ -11,10 +11,10 @@ class BotMessageFormatter
     @text_channel = select_hobby_category_channels.sample
   end
 
-  def create_embed_message
+  def create_embed_message(embed_description: nil )
     {
       title: EMBED_TITLE,
-      description: format_embed_description,
+      description: embed_description || format_embed_description,
       color: 3_066_993
     }
   end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -41,6 +41,6 @@ class BotMessageTest < Minitest::Test
   end
 
   def embed_hash_description
-    "チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n" + "説明： rubyについていろいろお話ししましょう〜\n" + "https://www.ruby-lang.org/ja/"
+    "チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/"
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -20,11 +20,8 @@ class BotMessageTest < Minitest::Test
 
   def test_post_message
     message_url = "#{Discordrb::API.api_base}/channels/#{ENV['DISCORD_RANDOM_CHANNEL_ID']}/messages"
-    first_message = stub_request(:post, message_url)
-                    .with(body: hash_including({ content: 'こんにちは！今日オススメのチャンネルを紹介をするよ〜' }))
     stub_message = stub_request(:post, message_url).with(body: hash_including(embed_hash))
     BotMessage.create(embed_hash_description)
-    assert_requested(first_message)
     assert_requested(stub_message)
   end
 
@@ -32,6 +29,7 @@ class BotMessageTest < Minitest::Test
 
   def embed_hash
     {
+      content: 'こんにちは！今日オススメのチャンネルを紹介をするよ〜',
       embed: {
         title: BotMessageFormatter::EMBED_TITLE,
         description: embed_hash_description,

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -39,6 +39,8 @@ class BotMessageTest < Minitest::Test
   end
 
   def embed_hash_description
-    "チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/"
+    <<~TEXT
+    チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/
+    TEXT
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -23,7 +23,7 @@ class BotMessageTest < Minitest::Test
     first_message = stub_request(:post, message_url)
                     .with(body: hash_including({ content: 'こんにちは！今日オススメのチャンネルを紹介をするよ〜' }))
     stub_message = stub_request(:post, message_url).with(body: hash_including(embed_hash))
-    BotMessage.create
+    BotMessage.create(embed_hash_description)
     assert_requested(first_message)
     assert_requested(stub_message)
   end
@@ -34,9 +34,13 @@ class BotMessageTest < Minitest::Test
     {
       embed: {
         title: BotMessageFormatter::EMBED_TITLE,
-        description: BotMessageFormatter.new.send(:format_embed_description),
+        description: embed_hash_description,
         color: 3_066_993
       }
     }
+  end
+
+  def embed_hash_description
+    "チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n" + "説明： rubyについていろいろお話ししましょう〜\n" + "https://www.ruby-lang.org/ja/"
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 require 'minitest/autorun'
 require_relative '../lib/discord_api'
 require_relative '../lib/channel_info'
 require_relative '../lib/bot_message_formatter'
 require_relative '../lib/bot_message'
 require 'webmock/minitest'
-include WebMock::API
 
 class BotMessageTest < Minitest::Test
+  include WebMock::API
+
   def setup
     WebMock.disable_net_connect!
   end
@@ -18,7 +21,7 @@ class BotMessageTest < Minitest::Test
   def test_post_message
     message_url = "#{Discordrb::API.api_base}/channels/#{ENV['DISCORD_RANDOM_CHANNEL_ID']}/messages"
     first_message = stub_request(:post, message_url)
-                      .with(body: hash_including({ content: 'こんにちは！今日オススメのチャンネルを紹介をするよ〜' }))
+                    .with(body: hash_including({ content: 'こんにちは！今日オススメのチャンネルを紹介をするよ〜' }))
     stub_message = stub_request(:post, message_url).with(body: hash_including(embed_hash))
     BotMessage.create
     assert_requested(first_message)
@@ -26,13 +29,14 @@ class BotMessageTest < Minitest::Test
   end
 
   private
+
   def embed_hash
     {
       embed: {
         title: BotMessageFormatter::EMBED_TITLE,
         description: BotMessageFormatter.new.send(:format_embed_description),
         color: 3_066_993
-      },
+      }
     }
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -40,7 +40,7 @@ class BotMessageTest < Minitest::Test
 
   def embed_hash_description
     <<~TEXT
-    チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/
+      チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/
     TEXT
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -1,0 +1,38 @@
+require 'minitest/autorun'
+require_relative '../lib/discord_api'
+require_relative '../lib/channel_info'
+require_relative '../lib/bot_message_formatter'
+require_relative '../lib/bot_message'
+require 'webmock/minitest'
+include WebMock::API
+
+class BotMessageTest < Minitest::Test
+  def setup
+    WebMock.disable_net_connect!
+  end
+
+  def teardown
+    WebMock.allow_net_connect!
+  end
+
+  def test_post_message
+    message_url = "#{Discordrb::API.api_base}/channels/#{ENV['DISCORD_RANDOM_CHANNEL_ID']}/messages"
+    first_message = stub_request(:post, message_url)
+                      .with(body: hash_including({ content: 'こんにちは！今日オススメのチャンネルを紹介をするよ〜' }))
+    stub_message = stub_request(:post, message_url).with(body: hash_including(embed_hash))
+    BotMessage.create
+    assert_requested(first_message)
+    assert_requested(stub_message)
+  end
+
+  private
+  def embed_hash
+    {
+      embed: {
+        title: BotMessageFormatter::EMBED_TITLE,
+        description: BotMessageFormatter.new.send(:format_embed_description),
+        color: 3_066_993
+      },
+    }
+  end
+end


### PR DESCRIPTION
- #11 

## 概要

`bot_message.rb`の`create`メソッドのテストを作成した。

```
# bot_message.rbのcreateメソッド

Discordrb::API::Channel.create_message(ENV['DISCORD_BOT_TOKEN'],
                                           ENV['DISCORD_RANDOM_CHANNEL_ID'],
                                           message,
                                           tts,
                                           embed_message)
```

メッセージが飛ばせているのか・きちんと飛ばしたいメッセージ内容(特に`embed_message`)が飛ばせているのかのテストを作成した。

また、テストで作成されるメッセージ内容を固定するために、`lib/bot_message.rb`と`lib/bot_message_formatter.rb`の中身を修正した。
これにより、`stub_request`で作成される`embed_message`と、`BotMessage.create`で作成される`embed_message`の内容が違うことによりテストが落ちてしまうという問題を解消した。
