### PR TITLE
コードレビュー修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,11 @@ require:
 Metrics/MethodLength:
   Exclude:
     - test/bot_message_formatter_test.rb
+    - test/channel_info_test.rb
+
+Metrics/ClassLength:
+  Exclude:
+    - test/channel_info_test.rb
 
 Layout/LineLength:
   Exclude:

--- a/lib/bot_message_formatter.rb
+++ b/lib/bot_message_formatter.rb
@@ -17,7 +17,7 @@ class BotMessageFormatter
     {
       title: EMBED_TITLE,
       description: format_embed_description,
-      color: 3_066_993
+      color: 0x2ECC71
     }
   end
 

--- a/lib/bot_message_formatter.rb
+++ b/lib/bot_message_formatter.rb
@@ -41,7 +41,7 @@ class BotMessageFormatter
 
   def format_embed_description
     description = "チャンネル名： [##{text_channel_name}](#{text_channel_url})"
-    description += topic_message unless text_channel_topic.nil?
+    description += topic_message if text_channel_topic
     description
   end
 end

--- a/lib/bot_message_formatter.rb
+++ b/lib/bot_message_formatter.rb
@@ -32,16 +32,21 @@ class BotMessageFormatter
   end
 
   def topic_message
-    "\n説明： #{text_channel_topic}"
+    "説明： #{text_channel_topic}"
   end
 
   def text_channel_url
     "https://discord.com/channels/#{@channel['guild_id']}/#{@channel['id']}"
   end
 
+  def text_channel_name_and_url
+    "チャンネル名： [##{text_channel_name}](#{text_channel_url})"
+  end
+
   def format_embed_description
-    description = "チャンネル名： [##{text_channel_name}](#{text_channel_url})"
-    description += topic_message if text_channel_topic
-    description
+    description = []
+    description << text_channel_name_and_url
+    description << topic_message if text_channel_topic
+    description.join("\n")
   end
 end

--- a/lib/bot_message_formatter.rb
+++ b/lib/bot_message_formatter.rb
@@ -3,6 +3,7 @@
 class BotMessageFormatter
   EMBED_TITLE = '本日のチャンネル紹介'
   MESSAGE = 'こんにちは！今日オススメのチャンネルを紹介をするよ〜'
+  private_constant :EMBED_TITLE, :MESSAGE
 
   def initialize(channel)
     @channel = channel

--- a/lib/channel_info.rb
+++ b/lib/channel_info.rb
@@ -4,6 +4,7 @@ require_relative 'discord_api'
 
 class ChannelInfo
   attr_reader :channels
+
   def initialize
     @channels = JSON.parse(call_all_channel_api)
   end

--- a/test/bot_message_formatter_test.rb
+++ b/test/bot_message_formatter_test.rb
@@ -1,0 +1,27 @@
+require_relative '../lib/bot_message_formatter'
+require 'minitest/autorun'
+
+class BotMessageTest < Minitest::Test
+  def setup
+    @formatter = BotMessageFormatter.new(channel)
+  end
+
+  def test_message
+    assert_equal 'こんにちは！今日オススメのチャンネルを紹介をするよ〜', @formatter.message
+  end
+
+  def test_embed_message
+    expected = expected_embed_message
+    assert_equal expected, @formatter.embed_message
+  end
+
+  private
+
+  def expected_embed_message
+    {:title=>"本日のチャンネル紹介", :description=>"チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", :color=>3066993}
+  end
+
+  def channel
+    {"id"=>"943713981581910036", "last_message_id"=>"956778837360934972", "type"=>0, "name"=>"ruby", "position"=>19, "parent_id"=>"933233655172726846", "topic"=>"rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", "guild_id"=>"933233655172726845", "permission_overwrites"=>[], "rate_limit_per_user"=>0, "nsfw"=>false}
+  end
+end

--- a/test/bot_message_formatter_test.rb
+++ b/test/bot_message_formatter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../lib/bot_message_formatter'
 require 'minitest/autorun'
 
@@ -18,10 +20,35 @@ class BotMessageTest < Minitest::Test
   private
 
   def expected_embed_message
-    {:title=>"本日のチャンネル紹介", :description=>"チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", :color=>3066993}
+    {
+      title: '本日のチャンネル紹介',
+      description: embed_message_description,
+      color: 3_066_993
+    }
+  end
+
+  def embed_message_description
+    text = <<~TEXT
+      チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)
+      説明： rubyについていろいろお話ししましょう〜
+      https://www.ruby-lang.org/ja/
+    TEXT
+    text.chomp
   end
 
   def channel
-    {"id"=>"943713981581910036", "last_message_id"=>"956778837360934972", "type"=>0, "name"=>"ruby", "position"=>19, "parent_id"=>"933233655172726846", "topic"=>"rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", "guild_id"=>"933233655172726845", "permission_overwrites"=>[], "rate_limit_per_user"=>0, "nsfw"=>false}
+    {
+      'id' => '943713981581910036',
+      'last_message_id' => '956778837360934972',
+      'type' => 0,
+      'name' => 'ruby',
+      'position' => 19,
+      'parent_id' => '933233655172726846',
+      'topic' => "rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/",
+      'guild_id' => '933233655172726845',
+      'permission_overwrites' => [],
+      'rate_limit_per_user' => 0,
+      'nsfw' => false
+    }
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -17,18 +17,8 @@ class BotMessageTest < Minitest::Test
     WebMock.allow_net_connect!
   end
 
-  # そもそもこのテストは何をやりたい？一番そこが曖昧な気がする。
-  # 何をテストしたい？
-  # → BotMessageのcreateメソッド!!
-  # BotMessageのcreateメソッドは何をやってる？
-  # → Discordにpost飛ばしてる。
   def test_post_message
     message_url = "#{Discordrb::API.api_base}/channels/#{ENV['DISCORD_CHANNEL_ID']}/messages"
-    # stub_request → postした結果をstubしてる。
-    # postした結果とは？ → message_url（ここではrandomチャンネルへのアクセス）へbodyをpostした結果。
-    # BotMessage.create(formatter)でcreateしたpostの結果と同じ結果だったらOKという内容
-    # hash_includingは指定したkeyとvalueの組以外のものは無視してくれる。という認識。
-    # エラーが出るというのは、BotMessage.create(formatter)でbodyの中身に、stubしてるbodyの中身がないってこと？
     stub_message = stub_request(:post, message_url).with(body: hash_including(embed_hash))
     formatter = BotMessageFormatter.new(channel)
     BotMessage.create(formatter)
@@ -49,11 +39,7 @@ class BotMessageTest < Minitest::Test
   end
 
   def embed_hash_description
-    <<~TEXT
-      チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)
-      説明： rubyについていろいろお話ししましょう〜
-      https://www.ruby-lang.org/ja/
-    TEXT
+    "チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/"
   end
 
   def channel

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -6,7 +6,7 @@ require_relative '../lib/bot_message'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-class BotMessageTest < Minitest::Test
+class BotMessageFormatterTest < Minitest::Test
   include WebMock::API
 
   def setup

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -17,10 +17,21 @@ class BotMessageTest < Minitest::Test
     WebMock.allow_net_connect!
   end
 
+  # そもそもこのテストは何をやりたい？一番そこが曖昧な気がする。
+  # 何をテストしたい？
+  # → BotMessageのcreateメソッド!!
+  # BotMessageのcreateメソッドは何をやってる？
+  # → Discordにpost飛ばしてる。
   def test_post_message
     message_url = "#{Discordrb::API.api_base}/channels/#{ENV['DISCORD_CHANNEL_ID']}/messages"
+    # stub_request → postした結果をstubしてる。
+    # postした結果とは？ → message_url（ここではrandomチャンネルへのアクセス）へbodyをpostした結果。
+    # BotMessage.create(formatter)でcreateしたpostの結果と同じ結果だったらOKという内容
+    # hash_includingは指定したkeyとvalueの組以外のものは無視してくれる。という認識。
+    # エラーが出るというのは、BotMessage.create(formatter)でbodyの中身に、stubしてるbodyの中身がないってこと？
     stub_message = stub_request(:post, message_url).with(body: hash_including(embed_hash))
-    BotMessage.create(embed_hash[:embed])
+    formatter = BotMessageFormatter.new(channel)
+    BotMessage.create(formatter)
     assert_requested(stub_message)
   end
 
@@ -43,5 +54,9 @@ class BotMessageTest < Minitest::Test
       説明： rubyについていろいろお話ししましょう〜
       https://www.ruby-lang.org/ja/
     TEXT
+  end
+
+  def channel
+    {"id"=>"943713981581910036", "last_message_id"=>"956778837360934972", "type"=>0, "name"=>"ruby", "position"=>19, "parent_id"=>"933233655172726846", "topic"=>"rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", "guild_id"=>"933233655172726845", "permission_overwrites"=>[], "rate_limit_per_user"=>0, "nsfw"=>false}
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -39,10 +39,27 @@ class BotMessageTest < Minitest::Test
   end
 
   def embed_hash_description
-    "チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)\n説明： rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/"
+    text = <<~TEXT
+      チャンネル名： [#ruby](https://discord.com/channels/933233655172726845/943713981581910036)
+      説明： rubyについていろいろお話ししましょう〜
+      https://www.ruby-lang.org/ja/
+    TEXT
+    text.chomp
   end
 
   def channel
-    {"id"=>"943713981581910036", "last_message_id"=>"956778837360934972", "type"=>0, "name"=>"ruby", "position"=>19, "parent_id"=>"933233655172726846", "topic"=>"rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", "guild_id"=>"933233655172726845", "permission_overwrites"=>[], "rate_limit_per_user"=>0, "nsfw"=>false}
+    {
+      'id' => '943713981581910036',
+      'last_message_id' => '956778837360934972',
+      'type' => 0,
+      'name' => 'ruby',
+      'position' => 19,
+      'parent_id' => '933233655172726846',
+      'topic' => "rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/",
+      'guild_id' => '933233655172726845',
+      'permission_overwrites' => [],
+      'rate_limit_per_user' => 0,
+      'nsfw' => false
+    }
   end
 end

--- a/test/bot_message_test.rb
+++ b/test/bot_message_test.rb
@@ -32,7 +32,7 @@ class BotMessageTest < Minitest::Test
       embed: {
         title: '本日のチャンネル紹介',
         description: embed_hash_description,
-        color: 3_066_993
+        color: 0x2ECC71
       }
     }
   end

--- a/test/channel_info_test.rb
+++ b/test/channel_info_test.rb
@@ -12,26 +12,14 @@ class ChannelInfoTest < Minitest::Test
     stub_request(:get, 'https://discord.com/api/v6/guilds/933233655172726845/channels')
       .with(headers: channel_header)
       .to_return(status: 200, body: channel_body.to_json, headers: {})
-    @channels = ChannelInfo.new.channels
   end
 
   def teardown
     WebMock.allow_net_connect!
   end
 
-  def test_include_hobby_channel
-    refute_empty(@channels.reject { |channel| channel['parent_id'] == hobby_category_id })
-    assert_empty(select_hobby_category_channels.reject { |channel| channel['parent_id'] == hobby_category_id })
-  end
-
-  def test_not_include_private_text_channel_in_announce_channels
-    refute_empty(@channels.reject { |channel| channel['permission_overwrites'].empty? })
-    assert_empty(select_hobby_category_channels.reject { |channel| channel['permission_overwrites'].empty? })
-  end
-
-  def test_not_include_minute_report_channel_in_announce_channels
-    refute_empty(@channels.select { |channel| channel['name'].include?('分報') })
-    assert_empty(select_hobby_category_channels.select { |channel| channel['name'].include?('分報') })
+  def test_select_hobby_category_channel
+    assert_equal ChannelInfo.new.choose, hobby_category_channel
   end
 
   private
@@ -50,7 +38,7 @@ class ChannelInfoTest < Minitest::Test
   def channel_body
     [
       # 趣味カテゴリー
-      { id: '933233655172726846', type: 4, name: '趣味', position: 11, parent_id: '933233655172726846', guild_id: '933233655172726845',
+      { id: '933233655172726846', type: 4, name: '趣味', position: 11, guild_id: '933233655172726845',
         permission_overwrites: [] },
       # 趣味カテゴリーチャンネル
       { id: '943713981581910036', last_message_id: '956778837360934972', type: 0, name: 'ruby', position: 19, parent_id: '933233655172726846',
@@ -79,15 +67,7 @@ class ChannelInfoTest < Minitest::Test
     ]
   end
 
-  def select_hobby_category
-    @channels.select { |channel| channel['name'].include?('趣味') }
-  end
-
-  def hobby_category_id
-    select_hobby_category[0]['id']
-  end
-
-  def select_hobby_category_channels
-    @channels.select { |channel| channel['parent_id'] == hobby_category_id }
+  def hobby_category_channel
+    {"id"=>"943713981581910036", "last_message_id"=>"956778837360934972", "type"=>0, "name"=>"ruby", "position"=>19, "parent_id"=>"933233655172726846", "topic"=>"rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", "guild_id"=>"933233655172726845", "permission_overwrites"=>[], "rate_limit_per_user"=>0, "nsfw"=>false}
   end
 end

--- a/test/channel_info_test.rb
+++ b/test/channel_info_test.rb
@@ -38,36 +38,126 @@ class ChannelInfoTest < Minitest::Test
   def channel_body
     [
       # 趣味カテゴリー
-      { id: '933233655172726846', type: 4, name: '趣味', position: 11, guild_id: '933233655172726845',
-        permission_overwrites: [] },
+      {
+        id: '933233655172726846',
+        type: 4,
+        name: '趣味',
+        position: 11,
+        guild_id: '933233655172726845',
+        permission_overwrites: []
+      },
       # 趣味カテゴリーチャンネル
-      { id: '943713981581910036', last_message_id: '956778837360934972', type: 0, name: 'ruby', position: 19, parent_id: '933233655172726846',
-        topic: "rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", guild_id: '933233655172726845', permission_overwrites: [], rate_limit_per_user: 0, nsfw: false },
+      {
+        id: '943713981581910036',
+        last_message_id: '956778837360934972',
+        type: 0,
+        name: 'ruby',
+        position: 19,
+        parent_id: '933233655172726846',
+        topic: "rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/",
+        guild_id: '933233655172726845',
+        permission_overwrites: [],
+        rate_limit_per_user: 0,
+        nsfw: false
+      },
       # お知らせカテゴリー
-      { id: '951639452927807499', type: 4, name: 'お知らせ', position: 0, parent_id:
-        nil, guild_id: '933233655172726845', permission_overwrites: [] },
+      {
+        id: '951639452927807499',
+        type: 4,
+        name: 'お知らせ',
+        position: 0,
+        parent_id: nil,
+        guild_id: '933233655172726845',
+        permission_overwrites: []
+      },
       # お知らせカテゴリーのチャンネル
-      { id: '933233655172726848', last_message_id: '950983610180182048',
-        type: 0, name: '全体のお知らせ', position: 0, parent_id: '951639452927807499', topic: 'generalチャンネルです。',
-        guild_id: '933233655172726845', permission_overwrites: [], rate_limit_per_user: 0, nsfw: false },
+      {
+        id: '933233655172726848',
+        last_message_id: '950983610180182048',
+        type: 0,
+        name: '全体のお知らせ',
+        position: 0,
+        parent_id: '951639452927807499',
+        topic: 'generalチャンネルです。',
+        guild_id: '933233655172726845',
+        permission_overwrites: [],
+        rate_limit_per_user: 0,
+        nsfw: false
+      },
       # プライベートカテゴリ
-      { id: '951645520357621780', type: 4, name: '企業×フィヨルド',
-        position: 9, parent_id: nil, guild_id: '933233655172726845', permission_overwrites: [] },
+      {
+        id: '951645520357621780',
+        type: 4,
+        name: '企業×フィヨルド',
+        position: 9,
+        parent_id: nil,
+        guild_id: '933233655172726845',
+        permission_overwrites: []
+      },
       # プライベートチャンネル
-      { id: '951647258775027782',
-        last_message_id: nil, type: 0, name: '株式会社xxさん',
-        position: 15, parent_id: '951645520357621780', topic: nil, guild_id: '933233655172726845', permission_overwrites: [{ id: '933233655172726845', type: 'role', allow: 0, deny: 1024, allow_new: '0', deny_new: '1024' }],
-        rate_limit_per_user: 0, nsfw: false },
+      {
+        id: '951647258775027782',
+        last_message_id: nil,
+        type: 0,
+        name: '株式会社xxさん',
+        position: 15,
+        parent_id: '951645520357621780',
+        topic: nil,
+        guild_id: '933233655172726845',
+        permission_overwrites:
+          [
+            {
+              id: '933233655172726845',
+              type: 'role',
+              allow: 0,
+              deny: 1024,
+              allow_new: '0',
+              deny_new: '1024'
+            }
+          ],
+        rate_limit_per_user: 0,
+        nsfw: false
+      },
       # 分報カテゴリー
-      { id: '951645972944011265', type: 4, name: 'M（ひとりごと・分報）',
-        position: 13, parent_id: nil, guild_id: '933233655172726845', permission_overwrites: [] },
+      {
+        id: '951645972944011265',
+        type: 4,
+        name: 'M（ひとりごと・分報）',
+        position: 13,
+        parent_id: nil,
+        guild_id: '933233655172726845',
+        permission_overwrites: []
+      },
       # 分報チャンネル
-      { id: '951648168167239740', last_message_id: nil, type: 0, name: 'maeda🛌', position: 21, parent_id: '951645972944011265', topic: nil,
-        guild_id: '933233655172726845', permission_overwrites: [], rate_limit_per_user: 0, nsfw: false }
+      {
+        id: '951648168167239740',
+        last_message_id: nil,
+        type: 0,
+        name: 'maeda🛌',
+        position: 21,
+        parent_id: '951645972944011265',
+        topic: nil,
+        guild_id: '933233655172726845',
+        permission_overwrites: [],
+        rate_limit_per_user: 0,
+        nsfw: false
+      }
     ]
   end
 
   def hobby_category_channel
-    {"id"=>"943713981581910036", "last_message_id"=>"956778837360934972", "type"=>0, "name"=>"ruby", "position"=>19, "parent_id"=>"933233655172726846", "topic"=>"rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/", "guild_id"=>"933233655172726845", "permission_overwrites"=>[], "rate_limit_per_user"=>0, "nsfw"=>false}
+    {
+      'id' => '943713981581910036',
+      'last_message_id' => '956778837360934972',
+      'type' => 0,
+      'name' => 'ruby',
+      'position' => 19,
+      'parent_id' => '933233655172726846',
+      'topic' => "rubyについていろいろお話ししましょう〜\nhttps://www.ruby-lang.org/ja/",
+      'guild_id' => '933233655172726845',
+      'permission_overwrites' => [],
+      'rate_limit_per_user' => 0,
+      'nsfw' => false
+    }
   end
 end

--- a/test/channel_info_test.rb
+++ b/test/channel_info_test.rb
@@ -19,7 +19,7 @@ class ChannelInfoTest < Minitest::Test
   end
 
   def test_select_hobby_category_channel
-    assert_equal ChannelInfo.new.choose, hobby_category_channel
+    assert_equal hobby_category_channel, ChannelInfo.new.choose
   end
 
   private


### PR DESCRIPTION
## コードレビュー修正（梅本さんからの指摘内容↓）
### コード
- [x] ここはスタイル的に 1 行空けたほうが良さそうです (RuboCop でも指摘されていそう) 。
https://github.com/maeda-seina/piyochan-bot/blob/65d84b56670dbc486ec36b78d77c5ead5681d4a3/lib/channel_info.rb#L6-L7

- [x] クラスの外からは使われないのでこの定数は private const にすると良さそうです。
https://github.com/maeda-seina/piyochan-bot/blob/1ca791e9d43619dea4168213f394264d73cbfe89/lib/bot_message_formatter.rb#L4-L5

- [x] これは 0x... という 16 進数のリテラルを使って書いておいたほうが分かりやすいでしょう。
https://github.com/maeda-seina/piyochan-bot/blob/1ca791e9d43619dea4168213f394264d73cbfe89/lib/bot_message_formatter.rb#L19

- [x] unless と nil? の組み合わせだとどの条件のときに true / false がどうなるかを直感的に判断しにくいので、素直に if text_channel_topic のように書くと良いでしょう。
https://github.com/maeda-seina/piyochan-bot/blob/1ca791e9d43619dea4168213f394264d73cbfe89/lib/bot_message_formatter.rb#L43

- [x] 先頭の改行が何のための改行か分かりにくいので format_embed_description を以下のように修正すると良いかもですね。合わせて「チャンネル名：...」のところもメソッドになっていると良いかも？
https://github.com/maeda-seina/piyochan-bot/blob/1ca791e9d43619dea4168213f394264d73cbfe89/lib/bot_message_formatter.rb#L34
```rb
description = []
description << "チャンネル名： [##{text_channel_name}](#{text_channel_url})"
description << topic_message if text_channel_topic
description.join("\n")
```

---
### テスト 
- [x] lib 以下にある public な method に対してはすべてテストがあったほうが良いと思います。今だと bot_message_formatter.rb と discord_api.rb に対応するテストがなさそう？ API が絡んでいてテストを書くのが難しいとかもあるかもしれないので、そのへんは要検討です。

- [x] ChannelInfo クラスの public method はあくまで choose なので、そこで適切なチャンネルの情報が返ってくる and/or 含まれていてはいけないチャンネルの情報は返ってこないことをテストしておけば良いかなと思いました。もし sample に再現性を持たせる必要があれば srand で固定の seed を設定すれば良さそうです。
https://github.com/maeda-seina/piyochan-bot/blob/65d84b56670dbc486ec36b78d77c5ead5681d4a3/test/channel_info_test.rb#L22-L35

- [x] ここは formatter を使うように直してあげる必要がありそうでした。
https://github.com/maeda-seina/piyochan-bot/blob/bdd83ee89f51beea074af664fc8f3903698fa82b/test/bot_message_test.rb#L23


## お伝えすること
### テスト内容について
- channel_info_test.rbのテスト内容修正
→ ChannelInfoクラスのpublicメソッド（chooseメソッド）をテストするよう修正しました。

- bot_message_test.rbのテスト内容修正
→ formatterを使うよう修正しました！

- 作成できてないテストの追加について
> lib 以下にある public な method に対してはすべてテストがあったほうが良いと思います。今だと bot_message_formatter.rb と discord_api.rb に対応するテストがなさそう？ API が絡んでいてテストを書くのが難しいとかもあるかもしれないので、そのへんは要検討です。

bot_message_formatter_test.rbを作成しました。→ https://github.com/maeda-seina/piyochan-bot/pull/65/commits/c414d2430e163e86e4336a980f48533a1f4f267a

また、discord_api.rbのテストについてはどう書けばいいのかわからなかったため作成しておりません。（Discordrbのメソッドを使用しているためテストしなくてもいいのではないか？とも思いました。）
梅本さんはどう思われますでしょうか？ご意見お聞かせください:bow: